### PR TITLE
Rename `@serial` to `@pickled`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Project Lombok.
   - [General utility decorators](#general-utility-decorators)
     - [`@threaded`](#threaded)
     - [`@repeat`](#repeat)
-    - [`@serial`](#serial)
+    - [`@pickled`](#pickled)
   - [Benchmark decorators](#benchmark-decorators)
     - [`@timeit`](#timeit)
     - [`@access_counter`](#access_counter)
@@ -273,12 +273,12 @@ Hello world!
 Hello world!
 ```
 
-### @serial
-The `@serial` decorator adds `__dump__` and `__load__` to a class for pickling convenience.
+### @pickled
+The `@pickled` decorator adds `__dump__` and `__load__` to a class for pickling convenience.
 
 `__dump__` and `__load__` take in the target and source pickle file paths respectively.
 
-This decorator takes in an optional `protocol` argument (e.g. `@serial(protocol=5)`) specifiying the [pickling protocol](https://docs.python.org/3/library/pickle.html#data-stream-format). 
+This decorator takes in an optional `protocol` argument (e.g. `@pickled(protocol=5)`) specifiying the [pickle protocol](https://docs.python.org/3/library/pickle.html#data-stream-format). 
 
 #### Python
 
@@ -301,7 +301,7 @@ class Person:
 
 ```python3
 @data
-@serial(protocol=5)
+@pickled(protocol=5)
 class Person:
     name: str
 ```

--- a/paprika/oo.py
+++ b/paprika/oo.py
@@ -114,7 +114,7 @@ def singleton(cls):
     return wrapper_singleton
 
 
-def serial(decorated_class=None, protocol=None):
+def pickled(decorated_class=None, protocol=None):
     def decorator(decorated_class):
         def __dump__(self, file_path): 
             with open(file_path, "wb") as f:

--- a/tests/test_oo.py
+++ b/tests/test_oo.py
@@ -45,7 +45,7 @@ class OOTestCases(unittest.TestCase):
     class TestPickledClass:
         field1: Any
 
-    @given(st.binary())
+    @given(st.binary(min_size=100))
     @settings(max_examples=10)
     def test_pickled(self, b):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -62,7 +62,7 @@ class OOTestCases(unittest.TestCase):
     class TestPickledClassProtocol3:
         field1: Any
         
-    @given(st.binary())
+    @given(st.binary(min_size=100))
     @settings(max_examples=10)
     def test_pickled_protocol_4(self, b):
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_oo.py
+++ b/tests/test_oo.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 from typing import Any
 from hypothesis import given, settings, strategies as st
-from paprika import data, NonNull, singleton, serial
+from paprika import data, NonNull, singleton, pickled
 class OOTestCases(unittest.TestCase):
     @data
     class TestClass:
@@ -41,35 +41,35 @@ class OOTestCases(unittest.TestCase):
         self.assertEqual(s1, s2)
 
     @data
-    @serial
-    class TestSerialClass:
+    @pickled
+    class TestPickledClass:
         field1: Any
 
     @given(st.binary())
     @settings(max_examples=10)
-    def test_serial(self, b):
+    def test_pickled(self, b):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_file_path = os.path.join(tmp_dir, 'data.pickle')
 
-            c = self.TestSerialClass(b)
+            c = self.TestPickledClass(b)
             c.__dump__(tmp_file_path)
-            deserialized = self.TestSerialClass.__load__(tmp_file_path)
+            unpickled = self.TestPickledClass.__load__(tmp_file_path)
 
-            self.assertEqual(deserialized, c)
+            self.assertEqual(unpickled, c)
             
     @data
-    @serial(protocol=3)
-    class TestSerialClassProtocol3:
+    @pickled(protocol=3)
+    class TestPickledClassProtocol3:
         field1: Any
         
     @given(st.binary())
     @settings(max_examples=10)
-    def test_serial_protocol_4(self, b):
+    def test_pickled_protocol_4(self, b):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_file_path = os.path.join(tmp_dir, 'data.pickle')
 
-            c = self.TestSerialClassProtocol3(b)
+            c = self.TestPickledClassProtocol3(b)
             c.__dump__(tmp_file_path)
-            deserialized = self.TestSerialClassProtocol3.__load__(tmp_file_path)
+            unpickled = self.TestPickledClassProtocol3.__load__(tmp_file_path)
 
-            self.assertEqual(deserialized, c)
+            self.assertEqual(unpickled, c)


### PR DESCRIPTION
## Summary
`@serial` is misleading and may instead be misconstrued to mean
JSON serializing.
Use `@pickled` instead

While we're at it, make hypothesis generate bytes of `min_size=100` during randomised testing.

## Test Plan
Unit tests pass.